### PR TITLE
#169519885 UI page of all user records

### DIFF
--- a/UI/pages/user-all-records-list.html
+++ b/UI/pages/user-all-records-list.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    
+    <title>Document</title>
+
+    <link rel="stylesheet" href="../css/style.css" />
+</head>
+<body class="dashboad-body">
+    <header>
+        <div class="container-dashboad container-flex">
+            <div class="header-logo header-logo-dash">
+                    <span class="logo-icon">&#127757; </span>
+                    <span class="logo-word"> Boadcaster</span>
+            </div>
+            <div class="header-user">
+                <h1 class="user-info">
+                    <span class="user-logo">&#128100;</span>
+                    <span class="user-name">Jasmin</span>
+                </h1>
+                <a href="user-sing-in.html" class="sinup-btn log-out to-change">Sign out</a>
+                <p class="menu-icon hide-me">&#9776;</p>
+            </div>
+        </div>
+    </header>
+
+    <section class="sec-dashboad">
+        <div class="menus">
+            <ul class="menu-list">
+                <li class="list-item"><a href="user-create-red-flag.html" class="item-link">Red-flag</a></li>
+                <!-- <li class="list-item red-sub span-data"><span class="item-link">Red-Flad<span class="trick">---------</span><span class="cross">&#9660;</span></span></li> -->
+                <div class="sub-menus show-me">
+                    <li class="list-item"><a href="user-draft-records-list.html" class="item-link">Draft</a></li>
+                    <li class="list-item"><a href="user-all-records-list.html" class="item-link">In process</a></li>
+                    <li class="list-item"><a href="user-all-records-list.html" class="item-link">Resolved</a></li>
+                    <li class="list-item"><a href="user-all-records-list.html" class="item-link">Rejected</a></li>
+                    <li class="list-item"><a href="user-all-records-list.html" class="item-link">All list</a></li>
+                </div>
+                <!-- <hr class="divide"> -->
+                <li class="list-item"><a href="user-create-intervention.html" class="item-link">Intervention</a></li>
+                <div class="sub-menus">
+                    <li class="list-item"><a href="user-draft-records-list.html" class="item-link">Draft</a></li>
+                    <li class="list-item"><a href="user-all-records-list.html" class="item-link">In process</a></li>
+                    <li class="list-item"><a href="user-all-records-list.html" class="item-link">Resolved</a></li>
+                    <li class="list-item"><a href="user-all-records-list.html" class="item-link">Rejected</a></li>
+                    <li class="list-item"><a href="user-all-records-list.html" class="item-link">All list</a></li>
+                </div>
+                <!-- <hr class="divide"> -->
+                <li class="list-item"><a href="user-sing-in.html" class="item-link">Sign out</a></li>
+            </ul>
+        </div>
+        <div class="sec-content">
+            <div class="dash-data">
+                <h1 class="medium-title dash-title">
+                    <span>Red-Flad List</span>
+                    <span class="records">233 records</span>
+                </h1>
+                <p class="table-th">
+                    <span class="table-td">Title</span>
+                    <span class="table-td">Comment</span>
+                    <span class="table-td">Date</span>
+                    <span class="table-td text-center">Action</span>
+                </p>
+
+                <div class="data-item">
+                    <div class="data-sumary">
+                        <p class="data-title hide-me">Title:</p>
+                        <p class="data-title to-change">Corruption in Traffic</p>
+                        <p class="data-content">corruption in Traffic ...</p>
+                        <p class="data-content">23 Sept 2019</p>
+                        <p class="data-actions container-flex">
+                            <button class="action more" onclick="//more_info()" >&#9660;</button>
+                        </p>
+                    </div>
+                    <div class="data-details hide-me">
+                        <p class="data-title"><strong>Title: </strong>corruption in Traffic</p>
+                        <p class="data-content to-hide">
+                            <strong>Status: </strong>
+                            [ <span class="in-draft">in draft</span>
+                            <span class="in-process">in process...</span>
+                            <span class="resolved">resolved</span>
+                            <span class="rejected">rejected</span> ]
+                        </p>
+                        <p class="data-content"><strong>Comment: </strong>corruption in Traffic ...</p>
+                        <p class="data-content"><strong>Location (Lat, Long): </strong>(234345, 34534534)</p>
+                        <p class="data-actions">
+                            <a href="record-details.html" class="action bottom-more">More info</a>
+                        </p>
+                    </div>
+                </div>
+                <div class="data-item">
+                        <div class="data-sumary">
+                            <p class="data-title hide-me">Title:</p>
+                            <p class="data-title to-change">Corruption in Traffic</p>
+                            <p class="data-content">corruption in Traffic ...</p>
+                            <p class="data-content">23 Sept 2019</p>
+                            <p class="data-actions container-flex">
+                                <button class="action more" onclick="//more_info()" >&#9660;</button>
+                            </p>
+                        </div>
+                        <div class="data-details hide-me">
+                            <p class="data-title"><strong>Title: </strong>corruption in Traffic</p>
+                            <p class="data-content to-hide">
+                                <strong>Status: </strong>
+                                [ <span class="in-draft">in draft</span>
+                                <span class="in-process">in process...</span>
+                                <span class="resolved">resolved</span>
+                                <span class="rejected">rejected</span> ]
+                            </p>
+                            <p class="data-content"><strong>Comment: </strong>corruption in Traffic ...</p>
+                            <p class="data-content"><strong>Location (Lat, Long): </strong>(234345, 34534534)</p>
+                            <p class="data-actions">
+                                <a href="record-details.html" class="action bottom-more">More info</a>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="data-item">
+                            <div class="data-sumary">
+                                <p class="data-title hide-me">Title:</p>
+                                <p class="data-title to-change">Corruption in Traffic</p>
+                                <p class="data-content">corruption in Traffic ...</p>
+                                <p class="data-content">23 Sept 2019</p>
+                                <p class="data-actions container-flex">
+                                    <button class="action more" onclick="//more_info()" >&#9660;</button>
+                                </p>
+                            </div>
+                            <div class="data-details hide-me">
+                                <p class="data-title"><strong>Title: </strong>corruption in Traffic</p>
+                                <p class="data-content to-hide">
+                                    <strong>Status: </strong>
+                                    [ <span class="in-draft">in draft</span>
+                                    <span class="in-process">in process...</span>
+                                    <span class="resolved">resolved</span>
+                                    <span class="rejected">rejected</span> ]
+                                </p>
+                                <p class="data-content"><strong>Comment: </strong>corruption in Traffic ...</p>
+                                <p class="data-content"><strong>Location (Lat, Long): </strong>(234345, 34534534)</p>
+                                <p class="data-actions">
+                                    <a href="record-details.html" class="action bottom-more">More info</a>
+                                </p>
+                            </div>
+                        </div>
+                        <div class="data-item">
+                                <div class="data-sumary">
+                                    <p class="data-title hide-me">Title:</p>
+                                    <p class="data-title to-change">Corruption in Traffic</p>
+                                    <p class="data-content">corruption in Traffic ...</p>
+                                    <p class="data-content">23 Sept 2019</p>
+                                    <p class="data-actions container-flex">
+                                        <button class="action more" onclick="//more_info()" >&#9660;</button>
+                                    </p>
+                                </div>
+                                <div class="data-details hide-me">
+                                    <p class="data-title"><strong>Title: </strong>corruption in Traffic</p>
+                                    <p class="data-content to-hide">
+                                        <strong>Status: </strong>
+                                        [ <span class="in-draft">in draft</span>
+                                        <span class="in-process">in process...</span>
+                                        <span class="resolved">resolved</span>
+                                        <span class="rejected">rejected</span> ]
+                                    </p>
+                                    <p class="data-content"><strong>Comment: </strong>corruption in Traffic ...</p>
+                                    <p class="data-content"><strong>Location (Lat, Long): </strong>(234345, 34534534)</p>
+                                    <p class="data-actions">
+                                        <a href="record-details.html" class="action bottom-more">More info</a>
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="data-item">
+                                    <div class="data-sumary">
+                                        <p class="data-title hide-me">Title:</p>
+                                        <p class="data-title to-change">Corruption in Traffic</p>
+                                        <p class="data-content">corruption in Traffic ...</p>
+                                        <p class="data-content">23 Sept 2019</p>
+                                        <p class="data-actions container-flex">
+                                            <button class="action more" onclick="//more_info()" >&#9660;</button>
+                                        </p>
+                                    </div>
+                                    <div class="data-details hide-me">
+                                        <p class="data-title"><strong>Title: </strong>corruption in Traffic</p>
+                                        <p class="data-content to-hide">
+                                            <strong>Status: </strong>
+                                            [ <span class="in-draft">in draft</span>
+                                            <span class="in-process">in process...</span>
+                                            <span class="resolved">resolved</span>
+                                            <span class="rejected">rejected</span> ]
+                                        </p>
+                                        <p class="data-content"><strong>Comment: </strong>corruption in Traffic ...</p>
+                                        <p class="data-content"><strong>Location (Lat, Long): </strong>(234345, 34534534)</p>
+                                        <p class="data-actions">
+                                            <a href="record-details.html" class="action bottom-more">More info</a>
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="data-item">
+                                        <div class="data-sumary">
+                                            <p class="data-title hide-me">Title:</p>
+                                            <p class="data-title to-change">Corruption in Traffic</p>
+                                            <p class="data-content">corruption in Traffic ...</p>
+                                            <p class="data-content">23 Sept 2019</p>
+                                            <p class="data-actions container-flex">
+                                                <button class="action more" onclick="//more_info()" >&#9660;</button>
+                                            </p>
+                                        </div>
+                                        <div class="data-details hide-me">
+                                            <p class="data-title"><strong>Title: </strong>corruption in Traffic</p>
+                                            <p class="data-content to-hide">
+                                                <strong>Status: </strong>
+                                                [ <span class="in-draft">in draft</span>
+                                                <span class="in-process">in process...</span>
+                                                <span class="resolved">resolved</span>
+                                                <span class="rejected">rejected</span> ]
+                                            </p>
+                                            <p class="data-content"><strong>Comment: </strong>corruption in Traffic ...</p>
+                                            <p class="data-content"><strong>Location (Lat, Long): </strong>(234345, 34534534)</p>
+                                            <p class="data-actions">
+                                                <a href="record-details.html" class="action bottom-more">More info</a>
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <div class="data-item">
+                                            <div class="data-sumary">
+                                                <p class="data-title hide-me">Title:</p>
+                                                <p class="data-title to-change">Corruption in Traffic</p>
+                                                <p class="data-content">corruption in Traffic ...</p>
+                                                <p class="data-content">23 Sept 2019</p>
+                                                <p class="data-actions container-flex">
+                                                    <button class="action more" onclick="//more_info()" >&#9660;</button>
+                                                </p>
+                                            </div>
+                                            <div class="data-details hide-me">
+                                                <p class="data-title"><strong>Title: </strong>corruption in Traffic</p>
+                                                <p class="data-content to-hide">
+                                                    <strong>Status: </strong>
+                                                    [ <span class="in-draft">in draft</span>
+                                                    <span class="in-process">in process...</span>
+                                                    <span class="resolved">resolved</span>
+                                                    <span class="rejected">rejected</span> ]
+                                                </p>
+                                                <p class="data-content"><strong>Comment: </strong>corruption in Traffic ...</p>
+                                                <p class="data-content"><strong>Location (Lat, Long): </strong>(234345, 34534534)</p>
+                                                <p class="data-actions">
+                                                    <a href="record-details.html" class="action bottom-more">More info</a>
+                                                </p>
+                                            </div>
+                                        </div>
+
+            </div>
+        </div>
+    </section>
+    
+    <footer>
+        <p class="copy-right">Copyright <span class="hint-text">&copy;</span> 2019 &#127757;Boadcaster</p>
+    </footer>
+    <script src="../js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
#### What does this PR do?
- creating a page that will help users to view all their records in the listed table
- this page will be used on both red-flag and intervention
- those records will be having different status (like in-draft, in-process, resolved and rejected)

#### Description of Task to be completed
- Designing all-records page and the record may be a red-flag or intervention
- implementing the design with HTML, CSS, and JS

#### How should this be manually tested?
- By cloning this Repo, open the UI folder (UI/pages/user-all-records-list.html)
- then open that [user-all-records-list.html] file with your favorite browser (like Google Chrome, ...)

#### Any background context you want to provide?
N/A

#### Screenshots (if appropriate)
![Screenshot from 2019-11-07 17-10-20](https://user-images.githubusercontent.com/37714031/68401000-a7739400-0181-11ea-8d0e-e9d91593e20b.png)

#### What are the relevant pivotal tracker stories?
#169519885